### PR TITLE
Fix figure path resolution and full-page layout

### DIFF
--- a/docs/tutorials/figure-positioning.md
+++ b/docs/tutorials/figure-positioning.md
@@ -93,6 +93,12 @@ As shown in @fig:results A, the data indicates...
 {#fig:schematic tex_position="p" width="\textwidth"}
 ```
 
+When `width="\textwidth"` is used with `tex_position="p"`, Rxiv-Maker creates a
+`figure*` environment to span the full page width, preventing captions from
+overflowing in two-column layouts. If the figure floats too far from the
+reference point, insert `<clearpage>` or `<float-barrier>` before the figure to
+force placement.
+
 ## Figure File Organization
 
 ### Ready Figures (Recommended)
@@ -120,6 +126,8 @@ FIGURES/
 ### Figure Appears on Wrong Page
 - Try `tex_position="!t"` to force top placement
 - For large figures, use `tex_position="p"` for dedicated page
+- Insert `<clearpage>` or `<float-barrier>` before the figure to keep it near
+  the reference point when using `tex_position="p"`
 
 ### Figure Too Large
 - Reduce `width` parameter: `width="0.7\linewidth"`

--- a/src/rxiv_maker/converters/figure_processor.py
+++ b/src/rxiv_maker/converters/figure_processor.py
@@ -152,15 +152,23 @@ def create_latex_figure_environment(
 
     # Handle new subdirectory structure: Figure__name.svg -> Figure__name/Figure__name.png
     if "/" not in latex_path.split("Figures/")[-1]:  # Only if not already in subdirectory
-        # Extract figure name from path like "Figures/Figure__name.svg"
         import os
+        from pathlib import Path
 
+        # Extract figure name from path like "Figures/Figure__name.svg"
         figure_name = os.path.splitext(os.path.basename(latex_path))[0]
         figure_ext = os.path.splitext(latex_path)[1]
 
         # Check if figure already exists as ready file (direct in Figures/ directory)
-        ready_figure_path = latex_path
-        if os.path.exists(ready_figure_path.replace("Figures/", "FIGURES/")):
+        ready_figure_path = latex_path.replace("Figures/", "FIGURES/")
+
+        # Resolve against manuscript path when available to avoid false negatives
+        manuscript_root = os.getenv("MANUSCRIPT_PATH")
+        ready_figure_fullpath = (
+            Path(manuscript_root) / ready_figure_path if manuscript_root else Path(ready_figure_path)
+        )
+
+        if ready_figure_fullpath.exists():
             # Ready figure exists, use it directly without subdirectory conversion
             # latex_path already contains the correct ready file path
             pass
@@ -192,7 +200,7 @@ def create_latex_figure_environment(
         attributes.get("span") == "2col"
         or attributes.get("twocolumn") == "true"
         or attributes.get("twocolumn") is True
-        or (width == "\\textwidth" and position != "p")  # Auto-detect, but not for dedicated page figures
+        or width == "\\textwidth"  # Auto-detect full-width figures regardless of position
     )
 
     # Only adjust positioning for two-column spanning figures that don't have explicit positioning


### PR DESCRIPTION
## Summary
- Fix figure path detection using MANUSCRIPT_PATH to avoid duplicating files
- Treat `width="\textwidth"` as two-column regardless of positioning for proper full-page figures
- Document tips for dedicated page figures and float barriers

## Testing
- `PYTHONPATH=src pytest -o addopts="" tests/unit/test_figure_processor.py`
- ⚠️ `pre-commit run --files docs/tutorials/figure-positioning.md src/rxiv_maker/converters/figure_processor.py` (failed to install pre-commit due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_b_68a05e4f88bc83298bbcedbaff06ad01