### PR TITLE
Respect tex_position p for full-page figures

### DIFF
--- a/docs/tutorials/figure-positioning.md
+++ b/docs/tutorials/figure-positioning.md
@@ -55,7 +55,7 @@ For figures that should span both columns in a two-column layout:
 {#fig:workflow width="\textwidth" tex_position="t"}
 ```
 
-**Note:** `width="\textwidth"` automatically creates a `figure*` environment for two-column spanning.
+**Note:** `width="\textwidth"` automatically creates a `figure*` environment for two-column spanning, except when `tex_position="p"` which keeps a standard `figure` on its own page.
 
 ## Panel References
 
@@ -93,11 +93,10 @@ As shown in @fig:results A, the data indicates...
 {#fig:schematic tex_position="p" width="\textwidth"}
 ```
 
-When `width="\textwidth"` is used with `tex_position="p"`, Rxiv-Maker creates a
-`figure*` environment to span the full page width, preventing captions from
-overflowing in two-column layouts. If the figure floats too far from the
-reference point, insert `<clearpage>` or `<float-barrier>` before the figure to
-force placement.
+When `width="\textwidth"` is used with `tex_position="p"`, Rxiv-Maker uses a
+standard `figure[p]` environment so the figure occupies a dedicated page. If
+the figure floats too far from the reference point, insert `<clearpage>` or
+`<float-barrier>` before the figure to force placement.
 
 ## Figure File Organization
 

--- a/src/rxiv_maker/converters/figure_processor.py
+++ b/src/rxiv_maker/converters/figure_processor.py
@@ -203,6 +203,11 @@ def create_latex_figure_environment(
         or width == "\\textwidth"  # Auto-detect full-width figures regardless of position
     )
 
+    if position == "p":
+        # Dedicated page figures should use standard figure environment
+        # even when width is set to \textwidth
+        is_twocolumn = False
+
     # Only adjust positioning for two-column spanning figures that don't have explicit positioning
     if is_twocolumn and position == "ht":
         # For two-column spanning figures with default positioning, use 'tp' for better placement


### PR DESCRIPTION
## Summary
- Ensure `tex_position="p"` uses a single-column figure, enabling dedicated float pages even with `width="\textwidth"`
- Clarify documentation on how `tex_position="p"` interacts with `width="\textwidth"`

## Testing
- `pre-commit run --files src/rxiv_maker/converters/figure_processor.py docs/tutorials/figure-positioning.md` *(fails: command not found)*
- `PYTHONPATH=src pytest -o addopts='' tests/e2e/test_dummy_manuscript_generator.py::TestE2EFigureWorkflow::test_guillaume_fullpage_figure_fix -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06476b9208329bf25a801a45a5e13